### PR TITLE
Add metrics for accepted and terminated connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = prometheus_ranch
 PROJECT_DESCRIPTION = Prometheus collector for Ranch
-PROJECT_VERSION = 0.1.0
+PROJECT_VERSION = 0.2.0
 DEPS = protobuffs prometheus
 
 dep_prometheus = git https://github.com/deadtrickster/prometheus.erl.git v4.6.0

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -39,6 +39,12 @@ The number of connection processes hosted the connection supervisor.
 `ranch_num_active_connections`::
 The number of active connection processes hosted by the connection supervisor.
 
+`ranch_num_accepted_connections`::
+The number of connection processes accepted by the connection supervisor.
+
+`ranch_num_terminated_connections`::
+The number of connection processes terminated by the connection supervisor.
+
 === Process metrics
 
 Metrics for the acceptor and connection supervisor processes comprising a

--- a/ebin/prometheus_ranch.app
+++ b/ebin/prometheus_ranch.app
@@ -1,6 +1,6 @@
 {application, 'prometheus_ranch', [
 	{description, "Prometheus collector for Ranch"},
-	{vsn, "0.1.0"},
+	{vsn, "0.2.0"},
 	{modules, ['prometheus_ranch_collector']},
 	{registered, []},
 	{applications, [kernel,stdlib,protobuffs,prometheus]},


### PR DESCRIPTION
This PR adds metrics for accepted and terminated connections, to be introduced to ranch with https://github.com/ninenines/ranch/pull/301. The collector will still work when used with a pre-#301 Ranch 2.x version, those metrics will not be exported in that case.

The new metrics are named ranch_num_accepted_connections and ranch_num_terminated_connections, and are mentioned accordingly in the README.

It also seemed proper to raise the project version to 0.2.0 with this.